### PR TITLE
fix: pass filename to less compiler, fix sourcemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "estree-walker": "^0.6.1",
     "less": "^3.9.0",
+    "lodash": "^4.17.11",
     "rollup-pluginutils": "^2.8.1"
   },
   "devDependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,6 +27,7 @@ export default {
     'crypto',
     'estree-walker',
     'fs',
+    'lodash/assign',
     'less',
     'path',
     'rollup-pluginutils',

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import less from 'less';
 import { createFilter } from 'rollup-pluginutils';
 import { randomBytes } from 'crypto';
 import { walk } from 'estree-walker';
+import assign from 'lodash/assign';
 
 // random string identifier to avoid function name collision inside a chunk
 const uid = randomBytes(8).toString('hex');
@@ -59,10 +60,10 @@ export default function plugin(options = {}) {
     },
     async transform(code, id) {
       if (!filter(id)) return null;
-      const css = await lessRender(code, options.option);
+      const css = await lessRender(code, assign(options.option, { filename: id }));
       return {
         code: `export default cssInject${uid}(${JSON.stringify(css.toString())});`,
-        map: null, // sourcemap must be inlined since it's style injection
+        map: { mappings: '' }, // sourcemap must be inlined since it's style injection
       };
     },
   };


### PR DESCRIPTION
* pass "filename" attribute to less compiler (fix imports not being resolved correctly)
* returns empty sourcemap as the rollup's doc says, using an empty object